### PR TITLE
Feature/create hiragana api client

### DIFF
--- a/hirakanaChanger.xcodeproj/project.pbxproj
+++ b/hirakanaChanger.xcodeproj/project.pbxproj
@@ -11,6 +11,12 @@
 		85259C8823E1A79F00B469E6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85259C8723E1A79F00B469E6 /* ViewController.swift */; };
 		85259C8B23E1A79F00B469E6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 85259C8923E1A79F00B469E6 /* Main.storyboard */; };
 		85259C8D23E1A7A100B469E6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85259C8C23E1A7A100B469E6 /* Assets.xcassets */; };
+		85490B3523E31025001EE003 /* HiraganaApiRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85490B3423E31025001EE003 /* HiraganaApiRequest.swift */; };
+		85490B3723E31403001EE003 /* HiraganaApiProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85490B3623E31403001EE003 /* HiraganaApiProvider.swift */; };
+		85490B3E23E322CB001EE003 /* HiraganaApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85490B3D23E322CB001EE003 /* HiraganaApi.swift */; };
+		85CF84FB23E50DC2008464B3 /* HiraganaApiResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CF84FA23E50DC2008464B3 /* HiraganaApiResponse.swift */; };
+		85CF84FD23E525D5008464B3 /* HiraganaApiListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CF84FC23E525D5008464B3 /* HiraganaApiListener.swift */; };
+		85CF84FF23E52FAA008464B3 /* HiraganaApiMessageListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CF84FE23E52FAA008464B3 /* HiraganaApiMessageListener.swift */; };
 		FF22E27E2AA6FD459C0876FB /* Pods_hirakanaChanger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5CE5EBE59A8C885DA50B8B5 /* Pods_hirakanaChanger.framework */; };
 /* End PBXBuildFile section */
 
@@ -21,6 +27,12 @@
 		85259C8A23E1A79F00B469E6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		85259C8C23E1A7A100B469E6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		85259C9123E1A7A100B469E6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		85490B3423E31025001EE003 /* HiraganaApiRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApiRequest.swift; sourceTree = "<group>"; };
+		85490B3623E31403001EE003 /* HiraganaApiProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApiProvider.swift; sourceTree = "<group>"; };
+		85490B3D23E322CB001EE003 /* HiraganaApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApi.swift; sourceTree = "<group>"; };
+		85CF84FA23E50DC2008464B3 /* HiraganaApiResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApiResponse.swift; sourceTree = "<group>"; };
+		85CF84FC23E525D5008464B3 /* HiraganaApiListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApiListener.swift; sourceTree = "<group>"; };
+		85CF84FE23E52FAA008464B3 /* HiraganaApiMessageListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiraganaApiMessageListener.swift; sourceTree = "<group>"; };
 		A03AC4BA653966E4EC392C2C /* Pods-hirakanaChanger.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-hirakanaChanger.release.xcconfig"; path = "Target Support Files/Pods-hirakanaChanger/Pods-hirakanaChanger.release.xcconfig"; sourceTree = "<group>"; };
 		B1F7DDEC19B2EA67B60A1E88 /* Pods-hirakanaChanger.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-hirakanaChanger.debug.xcconfig"; path = "Target Support Files/Pods-hirakanaChanger/Pods-hirakanaChanger.debug.xcconfig"; sourceTree = "<group>"; };
 		C5CE5EBE59A8C885DA50B8B5 /* Pods_hirakanaChanger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_hirakanaChanger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -44,7 +56,6 @@
 				B1F7DDEC19B2EA67B60A1E88 /* Pods-hirakanaChanger.debug.xcconfig */,
 				A03AC4BA653966E4EC392C2C /* Pods-hirakanaChanger.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -69,6 +80,7 @@
 		85259C8223E1A79F00B469E6 /* hirakanaChanger */ = {
 			isa = PBXGroup;
 			children = (
+				85490B3C23E31E0E001EE003 /* HiraganaApi */,
 				85259C8323E1A79F00B469E6 /* AppDelegate.swift */,
 				85259C8723E1A79F00B469E6 /* ViewController.swift */,
 				85259C8923E1A79F00B469E6 /* Main.storyboard */,
@@ -76,6 +88,19 @@
 				85259C9123E1A7A100B469E6 /* Info.plist */,
 			);
 			path = hirakanaChanger;
+			sourceTree = "<group>";
+		};
+		85490B3C23E31E0E001EE003 /* HiraganaApi */ = {
+			isa = PBXGroup;
+			children = (
+				85490B3D23E322CB001EE003 /* HiraganaApi.swift */,
+				85CF84FC23E525D5008464B3 /* HiraganaApiListener.swift */,
+				85CF84FE23E52FAA008464B3 /* HiraganaApiMessageListener.swift */,
+				85490B3623E31403001EE003 /* HiraganaApiProvider.swift */,
+				85490B3423E31025001EE003 /* HiraganaApiRequest.swift */,
+				85CF84FA23E50DC2008464B3 /* HiraganaApiResponse.swift */,
+			);
+			path = HiraganaApi;
 			sourceTree = "<group>";
 		};
 		C69A11FF72B629A4BFBA98F0 /* Frameworks */ = {
@@ -207,8 +232,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				85CF84FB23E50DC2008464B3 /* HiraganaApiResponse.swift in Sources */,
+				85490B3723E31403001EE003 /* HiraganaApiProvider.swift in Sources */,
+				85490B3E23E322CB001EE003 /* HiraganaApi.swift in Sources */,
 				85259C8823E1A79F00B469E6 /* ViewController.swift in Sources */,
 				85259C8423E1A79F00B469E6 /* AppDelegate.swift in Sources */,
+				85CF84FD23E525D5008464B3 /* HiraganaApiListener.swift in Sources */,
+				85CF84FF23E52FAA008464B3 /* HiraganaApiMessageListener.swift in Sources */,
+				85490B3523E31025001EE003 /* HiraganaApiRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/hirakanaChanger/Base.lproj/Main.storyboard
+++ b/hirakanaChanger/Base.lproj/Main.storyboard
@@ -24,6 +24,9 @@
                                     <segment title="ヒ"/>
                                 </segments>
                                 <color key="selectedSegmentTintColor" systemColor="systemGreenColor" red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <connections>
+                                    <action selector="segmentChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="cEZ-oY-4pp"/>
+                                </connections>
                             </segmentedControl>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="エラー文の表示" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Inf-hT-1hv">
                                 <rect key="frame" x="31" y="310" width="160" height="31"/>
@@ -54,6 +57,9 @@
                                         <color key="value" red="0.66962488821555832" green="0.98039215690000003" blue="0.84900535377660846" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="convertFieldChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="zWs-c0-FRu"/>
+                                </connections>
                             </textField>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>

--- a/hirakanaChanger/HiraganaApi/HiraganaApi.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApi.swift
@@ -1,0 +1,32 @@
+//
+//  HiraganaApi.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/01/30.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+/// ひらがなAPI実行クラス
+class HiraganaApi {
+  // POSTしか使えないため
+  private let method: HTTPMethod = .post
+  private let requestUrl = "https://labs.goo.ne.jp/api/hiragana"
+  private let requestHeader: HTTPHeaders = ["Content-Type": "application/json"]
+  private let apiListener: HiraganaApiListener
+  
+  init(apiListener: HiraganaApiListener) {
+    self.apiListener = apiListener
+  }
+  
+  /// ひらがなAPIの実行
+  /// - Parameter request: リクエスト
+  func requestApi(request: HiraganaApiRequest) {
+    Alamofire.request(self.requestUrl, method: self.method, parameters: request.Request, encoding: JSONEncoding.prettyPrinted, headers: self.requestHeader)
+      .responseString(encoding: .utf8) { response in
+        self.apiListener.onResponse(response: HiraganaApiResponse.create(jsonText: response.result.value), responseError: response.result.error)
+      }
+    }
+}

--- a/hirakanaChanger/HiraganaApi/HiraganaApi.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApi.swift
@@ -13,7 +13,6 @@ import Alamofire
 class HiraganaApi {
   // POSTしか使えないため
   private let method: HTTPMethod = .post
-  private let requestUrl = "https://labs.goo.ne.jp/api/hiragana"
   private let requestHeader: HTTPHeaders = ["Content-Type": "application/json"]
   private let apiListener: HiraganaApiListener
   
@@ -24,7 +23,7 @@ class HiraganaApi {
   /// ひらがなAPIの実行
   /// - Parameter request: リクエスト
   func requestApi(request: HiraganaApiRequest) {
-    Alamofire.request(self.requestUrl, method: self.method, parameters: request.Request, encoding: JSONEncoding.prettyPrinted, headers: self.requestHeader)
+    Alamofire.request(request.Url, method: self.method, parameters: request.Request, encoding: JSONEncoding.prettyPrinted, headers: self.requestHeader)
       .responseString(encoding: .utf8) { response in
         self.apiListener.onResponse(response: HiraganaApiResponse.create(jsonText: response.result.value), responseError: response.result.error)
       }

--- a/hirakanaChanger/HiraganaApi/HiraganaApiListener.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiListener.swift
@@ -1,0 +1,14 @@
+//
+//  HiraganaApiListener.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/02/01.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+
+/// ひらがなAPIのイベントリスナー
+protocol HiraganaApiListener: class {
+  func onResponse(response: HiraganaApiResponse?, responseError: Error?)
+}

--- a/hirakanaChanger/HiraganaApi/HiraganaApiMessageListener.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiMessageListener.swift
@@ -1,0 +1,14 @@
+//
+//  HiraganaApiMessageListener.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/02/01.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+
+/// ひらがなAPIのメッセージイベントリスナー
+protocol HiraganaApiMessageListener: class {
+  func onMessageListener(responseMessage: HiraganaApiResponse?, responseError: Error?)
+}

--- a/hirakanaChanger/HiraganaApi/HiraganaApiProvider.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiProvider.swift
@@ -1,0 +1,48 @@
+//
+//  HiraganaApiProvider.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/01/30.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+
+/// ひらがなAPIの管理クラス
+class HiraganaApiProvider: HiraganaApiListener {
+  private let outputType: String
+  private let responseMessageListener: HiraganaApiMessageListener
+  
+  private init(outputType: String, listener: HiraganaApiMessageListener) {
+    self.outputType = outputType
+    self.responseMessageListener = listener
+  }
+  
+  /// インスタンス作成前に出力種別の判定処理
+  /// - Parameter selectedIndex: 選択中インデックス
+  /// - Parameter listener: メッセージイベントリスナー
+  static func initialize(selectedIndex: Int, listener: HiraganaApiMessageListener) -> HiraganaApiProvider {
+    let outputType = (selectedIndex == 0) ? "hiragana":"katakana"
+    return HiraganaApiProvider(outputType: outputType, listener:listener)
+  }
+  /// ひらがなAPIの問合せ
+  /// - Parameter sentence: テキストフィールドに入力されたテキスト
+  /// - Parameter requestId: デフォルト値はnil
+  func inquireRequestApi(sentence: String?, requestId: String? = nil) {
+    // リクエストボディの型に合わせるためアンラップ
+    guard let sentence = sentence else { return }
+    if let requestId = requestId {
+      HiraganaApi(apiListener: self).requestApi(request: HiraganaApiRequest(requestId: requestId, sentence: sentence, outputType: self.outputType))
+    } else {
+      HiraganaApi(apiListener: self).requestApi(request: HiraganaApiRequest(sentence: sentence, outputType: self.outputType))
+    }
+  }
+  
+  // MARK: - HiraganaApiListener
+  /// ひらがなAPI実行結果の受け取り
+  /// - Parameter response: レスポンス
+  /// - Parameter responseError: レスポンス時のエラー内容
+  func onResponse(response: HiraganaApiResponse?, responseError: Error?) {
+    self.responseMessageListener.onMessageListener(responseMessage: response, responseError: responseError)
+  }
+}

--- a/hirakanaChanger/HiraganaApi/HiraganaApiRequest.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiRequest.swift
@@ -18,6 +18,13 @@ class HiraganaApiRequest {
   // リクエストパラメータ
   private let requestParameter: [String:String]
   
+  /// リクエストパラメータ群
+  var Request: [String: String] {
+    return self.requestParameter
+  }
+  var Url: String {
+    return "https://labs.goo.ne.jp/api/hiragana"
+  }
   init(sentence: String, outputType: String) {
     self.sentence = sentence
     self.outputType = outputType
@@ -27,12 +34,6 @@ class HiraganaApiRequest {
       "output_type": self.outputType
     ]
   }
-  
-  /// リクエストパラメータ群
-  var Request: [String: String] {
-    return self.requestParameter
-  }
-  
   /// リクエストIDを指定した場合のイニシャライザ
   /// - Parameters:
   ///   - requestId: リクエストID

--- a/hirakanaChanger/HiraganaApi/HiraganaApiRequest.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiRequest.swift
@@ -1,0 +1,52 @@
+//
+//  HiraganaApiRequest.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/01/30.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+
+/// ひらがなAPIのリクエストクラス
+class HiraganaApiRequest {
+  // アプリケーションID
+  private let appId = "cd937bcbd35f1440033fab1ea9fcda79daca8d87801a4f2c6887e2b6b0504f10"
+  private var requestId = ""
+  private let sentence: String
+  private let outputType: String
+  // リクエストパラメータ
+  private let requestParameter: [String:String]
+  
+  init(sentence: String, outputType: String) {
+    self.sentence = sentence
+    self.outputType = outputType
+    self.requestParameter = [
+      "app_id": self.appId,
+      "sentence": self.sentence,
+      "output_type": self.outputType
+    ]
+  }
+  
+  /// リクエストパラメータ群
+  var Request: [String: String] {
+    return self.requestParameter
+  }
+  
+  /// リクエストIDを指定した場合のイニシャライザ
+  /// - Parameters:
+  ///   - requestId: リクエストID
+  ///   - sentence: 解析対象テキスト
+  ///   - outputType: 出力種別
+  init(requestId: String, sentence: String, outputType: String) {
+    self.requestId = requestId
+    self.sentence = sentence
+    self.outputType = outputType
+    self.requestParameter = [
+      "app_id": self.appId,
+      "request_id": self.requestId,
+      "sentence": self.sentence,
+      "output_type": self.outputType
+    ]
+  }
+}

--- a/hirakanaChanger/HiraganaApi/HiraganaApiResponse.swift
+++ b/hirakanaChanger/HiraganaApi/HiraganaApiResponse.swift
@@ -1,0 +1,39 @@
+//
+//  HiraganaApiResponse.swift
+//  hirakanaChanger
+//
+//  Created by 溝口健太 on 2020/02/01.
+//  Copyright © 2020 溝口健太. All rights reserved.
+//
+
+import Foundation
+
+/// ひらがなAPIのレスポンスクラス
+class HiraganaApiResponse: Codable {
+  private let converted: String?
+  // 自動マッピング処理のため、スネークケースで定義
+  private let output_type: String?
+  private let request_id: String?
+  
+  var Converted: String? {
+    return self.converted
+  }
+  
+  /// デコード処理の隠蔽用
+  /// - Parameter jsonText: デコード対象文字列
+  static func create(jsonText: String?) -> HiraganaApiResponse? {
+    guard let jsonText = jsonText else { return nil }
+    return fromJson(jsonText: jsonText)
+  }
+  /// JSONのデコード処理
+  /// - Parameter jsonText: デコード対象文字列
+  static func fromJson(jsonText: String) -> HiraganaApiResponse? {
+    guard let jsonTextData = jsonText.data(using: .utf8) else { return nil }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    if let decodeJSON = try? decoder.decode(self, from: jsonTextData){
+      return decodeJSON
+    }
+      return nil
+    }
+}

--- a/hirakanaChanger/ViewController.swift
+++ b/hirakanaChanger/ViewController.swift
@@ -9,16 +9,41 @@
 import UIKit
 import TextFieldEffects
 
-class ViewController: UIViewController {
+class ViewController: UIViewController, HiraganaApiMessageListener {
   @IBOutlet weak var convertedText: UITextView!
   @IBOutlet weak var convertField: KaedeTextField!
   @IBOutlet weak var errorText: UILabel!
   @IBOutlet weak var convertSwitcher: UISegmentedControl!
+  // 選択中セグメント
+  private var selectedIndex = 0
   
   override func viewDidLoad() {
     super.viewDidLoad()
   }
-
-
+  
+  /// テキストフィールドの変換処理
+  /// - Parameter sender: convertField
+  @IBAction func convertFieldChanged(_ sender: Any) {
+    // TODO: デフォルトでrequestIdは指定しないが、時間があれば設定できるようにする
+    HiraganaApiProvider.initialize(selectedIndex: self.selectedIndex, listener: self).inquireRequestApi(sentence: self.convertField.text)
+  }
+  /// 出力種別の変更
+  /// - Parameter sender: convertSwitcher
+  @IBAction func segmentChanged(_ sender: Any) {
+    self.selectedIndex = convertSwitcher.selectedSegmentIndex
+  }
+  
+  // MARK: - HiraganaApiMessageListener
+  /// ひらがなAPIのレスポンス値を受け取る
+  /// - Parameter responseMessage: レスポンス
+  /// - Parameter responseError: レスポンス時のエラー内容
+  func onMessageListener(responseMessage: HiraganaApiResponse?, responseError: Error?) {
+    // API側でエラーがあった場合はエラー文の表示
+    if let error = responseError {
+      self.errorText.text = "ネットワーク環境を確認してください"
+      self.convertedText.text = error.localizedDescription
+    }
+    self.convertedText.text = responseMessage?.Converted
+  }
 }
 


### PR DESCRIPTION
## 概要

ひらがなAPIクライアントの実装

## 詳細

- テキストフィールドの入力時にAPI実行をすることで、データバインディングっぽく表示
- ネットワークエラー時は例外処理を考えたけど、レスポンスボディと一緒にVCに渡した方が楽だった為、後者の方法で実装
- リクエストボディのrequest_idは指定してもレスポンスで同じ値が返って来るだけで、アプリケーション層で使わない為、デフォルトでは指定しないように実装